### PR TITLE
Add required units for Darwin

### DIFF
--- a/sdl2.pas
+++ b/sdl2.pas
@@ -139,6 +139,13 @@ interface
       X,
       XLib;
   {$ENDIF}
+  
+  {$IFDEF DARWIN}
+    uses
+      X,
+      XLib,
+      CocoaAll;
+  {$ENDIF}
 
 const
 


### PR DESCRIPTION
sdlsyswm.inc needs the X and XLib units on platforms that define UNIX (including Darwin) for TXEvent, PDisplay, and TWindow, and the CocoaAll unit on Darwin for NSWindow.