### PR TITLE
Proper types for Renderer and Texture; Unify SetError(), GetError() and LIB_VERSION() behaviour

### DIFF
--- a/SDL2_image.pas
+++ b/SDL2_image.pas
@@ -76,7 +76,7 @@ const
    * version of the SDL_image library.
    *}
 
-procedure SDL_IMAGE_VERSION(var X: TSDL_Version);
+procedure SDL_IMAGE_VERSION(Out X: TSDL_Version);
 
   {* This function gets the version of the dynamically linked SDL_image library.
    * 
@@ -163,26 +163,26 @@ function IMG_SavePNG(surface: PSDL_Surface; const _file: PAnsiChar): SInt32 cdec
 function IMG_SavePNG_RW(surface: PSDL_Surface; dst: PSDL_RWops; freedst: SInt32): SInt32 cdecl; external IMG_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_IMG_SavePNG_RW' {$ENDIF} {$ENDIF};
 
 {* We'll use SDL for reporting errors *}
-function IMG_SetError(fmt: PAnsiChar): SInt32;
-function IMG_GetError: PAnsiChar;
+function IMG_SetError(fmt: PAnsiChar): SInt32; cdecl;
+function IMG_GetError: PAnsiChar; cdecl;
 
 implementation
 
-procedure SDL_IMAGE_VERSION(var X: TSDL_Version);
+procedure SDL_IMAGE_VERSION(Out X: TSDL_Version);
 begin
   X.major := SDL_IMAGE_MAJOR_VERSION;
   X.minor := SDL_IMAGE_MINOR_VERSION;
   X.patch := SDL_IMAGE_PATCHLEVEL;
 end;
 
-function IMG_SetError(fmt: PAnsiChar): SInt32;
+function IMG_SetError(fmt: PAnsiChar): SInt32; cdecl;
 begin
   Result := SDL_SetError(fmt);
 end;
 
-function IMG_GetError: PAnsiChar;
+function IMG_GetError: PAnsiChar; cdecl;
 begin
-  Result := SDL_GetError;
+  Result := SDL_GetError();
 end;
 
 end.

--- a/SDL2_mixer.pas
+++ b/SDL2_mixer.pas
@@ -70,7 +70,7 @@ const
   {* This macro can be used to fill a version structure with the compile-time
    * version of the SDL_mixer library.
    *}
-procedure SDL_MIXER_VERSION(X: PSDL_Version);
+procedure SDL_MIXER_VERSION(Out X: TSDL_Version);
 
   {* Backwards compatibility *}
 const
@@ -78,7 +78,7 @@ const
   MIX_MINOR_VERSION = SDL_MIXER_MINOR_VERSION;
   MIX_PATCHLEVEL    = SDL_MIXER_PATCHLEVEL;
 
-procedure MIX_VERSION(X: PSDL_Version);
+procedure MIX_VERSION(Out X: TSDL_Version);
 
   {* This function gets the version of the dynamically linked SDL_mixer library.
      it should NOT be used to fill a version structure, instead you should
@@ -651,19 +651,19 @@ function Mix_GetChunk(channel: Integer): PMix_Chunk cdecl; external MIX_LibName 
 procedure Mix_CloseAudio cdecl; external MIX_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_MIX_CloseAudio' {$ENDIF} {$ENDIF};
 
 {* We'll use SDL for reporting errors *}
-function Mix_SetError(const fmt: PAnsiChar): SInt32;
-function Mix_GetError: PAnsiChar;
+function Mix_SetError(const fmt: PAnsiChar): SInt32; cdecl;
+function Mix_GetError: PAnsiChar; cdecl;
 
 implementation
 
-procedure SDL_MIXER_VERSION(X: PSDL_Version);
+procedure SDL_MIXER_VERSION(Out X: TSDL_Version);
 begin
   X.major := SDL_MIXER_MAJOR_VERSION;
   X.minor := SDL_MIXER_MINOR_VERSION;
   X.patch := SDL_MIXER_PATCHLEVEL;
 end;
 
-procedure MIX_VERSION(X: PSDL_Version);
+procedure MIX_VERSION(Out X: TSDL_Version);
 begin
   SDL_MIXER_VERSION(X);
 end;
@@ -683,14 +683,14 @@ begin
   Result := Mix_LoadWAV_RW(SDL_RWFromFile(_file, 'rb'), 1);
 end;
 
-function Mix_SetError(const fmt: PAnsiChar): SInt32;
+function Mix_SetError(const fmt: PAnsiChar): SInt32; cdecl;
 begin
   Result := SDL_SetError(fmt);
 end;
 
-function Mix_GetError: PAnsiChar;
+function Mix_GetError: PAnsiChar; cdecl;
 begin
-  Result := SDL_GetError;
+  Result := SDL_GetError();
 end;
 
 end.

--- a/SDL2_net.pas
+++ b/SDL2_net.pas
@@ -22,7 +22,8 @@
       3. This notice may not be removed or altered from any source distribution.
     *}
     unit SDL2_net;
-     
+    
+    {$INCLUDE jedi.inc}
      
     interface
      
@@ -65,7 +66,7 @@
       {* This macro can be used to fill a version structure with the compile-time
        * version of the SDL_net library.
        *}
-    procedure SDL_NET_VERSION(var X: TSDL_Version);
+    procedure SDL_NET_VERSION(Out X: TSDL_Version);
      
       {* This function gets the version of the dynamically linked SDL_net library.
          it should NOT be used to fill a version structure, instead you should
@@ -340,8 +341,8 @@
     {* Error reporting functions                                           *}
     {***********************************************************************}
      
-    procedure SDLNet_SetError(const fmt: PAnsiChar); inline;
-    function SDLNet_GetError(): PAnsiChar; inline;
+    procedure SDLNet_SetError(const fmt: PAnsiChar); cdecl;
+    function SDLNet_GetError(): PAnsiChar; cdecl;
      
     {***********************************************************************}
     {* Inline functions to read/write network data                         *}
@@ -358,7 +359,7 @@
      
     implementation
      
-    procedure SDL_NET_VERSION(var X: TSDL_Version);
+    procedure SDL_NET_VERSION(Out X: TSDL_Version);
     begin
       X.major := SDL_NET_MAJOR_VERSION;
       X.minor := SDL_NET_MINOR_VERSION;
@@ -392,14 +393,14 @@
       Result := sock.ready;
     end;
      
-    procedure SDLNet_SetError(const fmt: PAnsiChar);
+    procedure SDLNet_SetError(const fmt: PAnsiChar); cdecl;
     begin
       SDL_SetError(fmt);
     end;
      
-    function SDLNet_GetError(): PAnsiChar;
+    function SDLNet_GetError(): PAnsiChar; cdecl;
     begin
-      Result := SDL_GetError;
+      Result := SDL_GetError();
     end;
      
     (*

--- a/SDL2_ttf.pas
+++ b/SDL2_ttf.pas
@@ -74,6 +74,8 @@ const
   SDL_TTF_MINOR_VERSION = 0;
   SDL_TTF_PATCHLEVEL    = 12;
 
+Procedure SDL_TTF_VERSION(Out X:TSDL_Version);
+
 {* Backwards compatibility *}
 const
   TTF_MAJOR_VERSION = SDL_TTF_MAJOR_VERSION;
@@ -263,19 +265,26 @@ function TTF_WasInit: Boolean cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDE
 function TTF_GetFontKerningSize(font: PTTF_Font; prev_index, index: Integer): Integer cdecl; external TTF_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_TTF_GetFontKerningSize' {$ENDIF} {$ENDIF};
 
 {* We'll use SDL for reporting errors *}
-function TTF_SetError(const fmt: PAnsiChar): SInt32;
-function TTF_GetError: PAnsiChar;
+function TTF_SetError(const fmt: PAnsiChar): SInt32; cdecl;
+function TTF_GetError: PAnsiChar; cdecl;
 
 implementation
 
-function TTF_SetError(const fmt: PAnsiChar): SInt32;
+Procedure SDL_TTF_VERSION(Out X:TSDL_Version);
+begin
+  x.major := SDL_TTF_MAJOR_VERSION;
+  x.minor := SDL_TTF_MINOR_VERSION;
+  x.patch := SDL_TTF_PATCHLEVEL;
+end;
+
+function TTF_SetError(const fmt: PAnsiChar): SInt32; cdecl;
 begin
   Result := SDL_SetError(fmt);
 end;
 
-function TTF_GetError: PAnsiChar;
+function TTF_GetError: PAnsiChar; cdecl;
 begin
-  Result := SDL_GetError;
+  Result := SDL_GetError();
 end;
 
 function TTF_RenderText(font: PTTF_Font; text: PAnsiChar; fg, bg: TSDL_Color): PSDL_Surface;

--- a/sdl2.pas
+++ b/sdl2.pas
@@ -212,11 +212,11 @@ const
 implementation
 
 //from "sdl_version.h"
-procedure SDL_VERSION(x: PSDL_Version);
+procedure SDL_VERSION(Out x: TSDL_Version);
 begin
-  x^.major := SDL_MAJOR_VERSION;
-  x^.minor := SDL_MINOR_VERSION;
-  x^.patch := SDL_PATCHLEVEL;
+  x.major := SDL_MAJOR_VERSION;
+  x.minor := SDL_MINOR_VERSION;
+  x.patch := SDL_PATCHLEVEL;
 end;
 
 function SDL_VERSIONNUM(X,Y,Z: UInt32): Cardinal;

--- a/sdlrenderer.inc
+++ b/sdlrenderer.inc
@@ -67,12 +67,14 @@ type
    *}
 
   PPSDL_Renderer = ^PSDL_Renderer;
-  PSDL_Renderer = Pointer; //todo!
+  PSDL_Renderer = ^TSDL_Renderer;
+  TSDL_Renderer = record;
 
   {**
    *  An efficient driver-specific representation of pixel data
    *}
-  PSDL_Texture = Pointer; //todo!
+  PSDL_Texture = ^TSDL_Texture;
+  TSDL_Texture = record;
 
   {* Function prototypes *}
 

--- a/sdlversion.inc
+++ b/sdlversion.inc
@@ -37,12 +37,12 @@ const
  *  determined with SDL_GetVersion(), which, unlike SDL_VERSION(),
  *  is not a macro.
  *
- *   x A pointer to a SDL_version struct to initialize.
+ *  x   An instance on TSDL_Version to fill with version data.
  *
  *  SDL_version
  *  SDL_GetVersion
  *}
-procedure SDL_VERSION(x: PSDL_Version);
+procedure SDL_VERSION(Out x: TSDL_Version);
 
 {**
  *  This macro turns the version numbers into a numeric value:


### PR DESCRIPTION
The first commit changes the definitions of `PSDL_Renderer` and `PSDL_Texture` types. Since they were defined as void pointers, you could pass just about any pointer to a function expecting a `PSDL_Renderer` or `PSDL_Texture` and it would happily compile. Now they have been given distinct types, allowing for proper compile-time type checking.

The second commit makes the SetError() and GetError() functions always use the C calling convention - even though under the hood they all use SDL error handling, I think it is better for the calling convention to be consistent. In the same way, LIB_VERSION behaviour was also unified.