### PR TITLE
functions repr. C macros corrected (see issue #28)

### DIFF
--- a/sdl2.pas
+++ b/sdl2.pas
@@ -341,29 +341,29 @@ end;
 
 //from "sdl_pixels.h"
 
-function SDL_PIXELFLAG(X: Cardinal): Boolean;
+function SDL_PIXELFLAG(X: Cardinal): Cardinal;
 begin
-  Result := (X shr 28) = $0F;
+  Result := (X shr 28) and $0F;
 end;
 
-function SDL_PIXELTYPE(X: Cardinal): Boolean;
+function SDL_PIXELTYPE(X: Cardinal): Cardinal;
 begin
-  Result := (X shr 24) = $0F;
+  Result := (X shr 24) and $0F;
 end;
 
-function SDL_PIXELORDER(X: Cardinal): Boolean;
+function SDL_PIXELORDER(X: Cardinal): Cardinal;
 begin
-  Result := (X shr 20) = $0F;
+  Result := (X shr 20) and $0F;
 end;
 
-function SDL_PIXELLAYOUT(X: Cardinal): Boolean;
+function SDL_PIXELLAYOUT(X: Cardinal): Cardinal;
 begin
-  Result := (X shr 16) = $0F;
+  Result := (X shr 16) and $0F;
 end;
 
-function SDL_BITSPERPIXEL(X: Cardinal): Boolean;
+function SDL_BITSPERPIXEL(X: Cardinal): Cardinal;
 begin
-  Result := (X shr 8) = $FF;
+  Result := (X shr 8) and $FF;
 end;
 
 function SDL_IsPixelFormat_FOURCC(format: Variant): Boolean;

--- a/sdlpixels.inc
+++ b/sdlpixels.inc
@@ -72,11 +72,11 @@ function SDL_DEFINE_PIXELFOURCC(A,B,C,D: Variant): Variant;
      ((bits) << 8) | ((bytes) << 0))
        }
 
-function SDL_PIXELFLAG(X: Cardinal): Boolean;
-function SDL_PIXELTYPE(X: Cardinal): Boolean;
-function SDL_PIXELORDER(X: Cardinal): Boolean;
-function SDL_PIXELLAYOUT(X: Cardinal): Boolean;
-function SDL_BITSPERPIXEL(X: Cardinal): Boolean;
+function SDL_PIXELFLAG(X: Cardinal): Cardinal;
+function SDL_PIXELTYPE(X: Cardinal): Cardinal;
+function SDL_PIXELORDER(X: Cardinal): Cardinal;
+function SDL_PIXELLAYOUT(X: Cardinal): Cardinal;
+function SDL_BITSPERPIXEL(X: Cardinal): Cardinal;
      {
 #define SDL_BYTESPERPIXEL(X) \
     (SDL_ISPIXELFORMAT_FOURCC(X) ? \
@@ -432,7 +432,7 @@ procedure SDL_FreeFormat(format: PSDL_PixelFormat) cdecl; external SDL_LibName {
    *  A new palette, or nil if there wasn't enough memory.
    *
    *  The palette entries are initialized to white.
-   *  
+   *
    *  SDL_FreePalette()
    *}
 


### PR DESCRIPTION
- functions return Cardinal instead of Bool values
- bitwise AND'ing introduced