### PR TITLE
Add functions introduced in SDL 2.0.4

### DIFF
--- a/sdl2.pas
+++ b/sdl2.pas
@@ -265,6 +265,14 @@ begin
   Result := (A.x = B.x) and (A.y = B.y) and (A.w = B.w) and (A.h = B.h);
 end;
 
+function SDL_PointInRect(const p: PSDL_Point; const r: PSDL_Rect): Boolean; Inline;
+begin
+  Result := 
+    (p^.x >= r^.x) and (p^.x < (r^.x + r^.w)) 
+    and 
+    (p^.y >= r^.y) and (p^.y < (r^.y + r^.h))
+end;
+
 //from "sdl_rwops.h"
 
 function SDL_RWsize(ctx: PSDL_RWops): SInt64;

--- a/sdlaudio.inc
+++ b/sdlaudio.inc
@@ -398,6 +398,102 @@ procedure SDL_MixAudio(dst: PUInt8; src: PUInt8; len: UInt32; volume: Integer) c
 procedure SDL_MixAudioFormat(dst: PUInt8; src: PUInt8; format: TSDL_AudioFormat; len: UInt32; volume: Integer) cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_MixAudioFormat' {$ENDIF} {$ENDIF};
 
   {**
+   *  Queue more audio on non-callback devices.
+   *
+   *  SDL offers two ways to feed audio to the device: you can either supply a
+   *  callback that SDL triggers with some frequency to obtain more audio
+   *  (pull method), or you can supply no callback, and then SDL will expect
+   *  you to supply data at regular intervals (push method) with this function.
+   *
+   *  There are no limits on the amount of data you can queue, short of
+   *  exhaustion of address space. Queued data will drain to the device as
+   *  necessary without further intervention from you. If the device needs
+   *  audio but there is not enough queued, it will play silence to make up
+   *  the difference. This means you will have skips in your audio playback
+   *  if you aren't routinely queueing sufficient data.
+   *
+   *  This function copies the supplied data, so you are safe to free it when
+   *  the function returns. This function is thread-safe, but queueing to the
+   *  same device from two threads at once does not promise which buffer will
+   *  be queued first.
+   *
+   *  You may not queue audio on a device that is using an application-supplied
+   *  callback; doing so returns an error. You have to use the audio callback
+   *  or queue audio with this function, but not both.
+   *
+   *  You should not call SDL_LockAudio() on the device before queueing; SDL
+   *  handles locking internally for this function.
+   *
+   *  \param dev The device ID to which we will queue audio.
+   *  \param data The data to queue to the device for later playback.
+   *  \param len The number of bytes (not samples!) to which (data) points.
+   *  \return zero on success, -1 on error.
+   *
+   *  \sa SDL_GetQueuedAudioSize
+   *  \sa SDL_ClearQueuedAudio
+   *}
+function SDL_QueueAudio(dev: TSDL_AudioDeviceID; data: Pointer; len: UInt32): SInt32; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_QueueAudio' {$ENDIF} {$ENDIF};
+
+  {**
+   *  Get the number of bytes of still-queued audio.
+   *
+   *  This is the number of bytes that have been queued for playback with
+   *  SDL_QueueAudio(), but have not yet been sent to the hardware.
+   *
+   *  Once we've sent it to the hardware, this function can not decide the exact
+   *  byte boundary of what has been played. It's possible that we just gave the
+   *  hardware several kilobytes right before you called this function, but it
+   *  hasn't played any of it yet, or maybe half of it, etc.
+   *
+   *  You may not queue audio on a device that is using an application-supplied
+   *  callback; calling this function on such a device always returns 0.
+   *  You have to use the audio callback or queue audio with SDL_QueueAudio(),
+   *  but not both.
+   *
+   *  You should not call SDL_LockAudio() on the device before querying; SDL
+   *  handles locking internally for this function.
+   *
+   *  \param dev The device ID of which we will query queued audio size.
+   *  \return Number of bytes (not samples!) of queued audio.
+   *
+   *  \sa SDL_QueueAudio
+   *  \sa SDL_ClearQueuedAudio
+   *}
+function SDL_GetQueuedAudioSize(dev: TSDL_AudioDeviceID): UInt32; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetQueuedAudioSize' {$ENDIF} {$ENDIF};
+
+  {**
+   *  Drop any queued audio data waiting to be sent to the hardware.
+   *
+   *  Immediately after this call, SDL_GetQueuedAudioSize() will return 0 and
+   *  the hardware will start playing silence if more audio isn't queued.
+   *
+   *  This will not prevent playback of queued audio that's already been sent
+   *  to the hardware, as we can not undo that, so expect there to be some
+   *  fraction of a second of audio that might still be heard. This can be
+   *  useful if you want to, say, drop any pending music during a level change
+   *  in your game.
+   *
+   *  You may not queue audio on a device that is using an application-supplied
+   *  callback; calling this function on such a device is always a no-op.
+   *  You have to use the audio callback or queue audio with SDL_QueueAudio(),
+   *  but not both.
+   *
+   *  You should not call SDL_LockAudio() on the device before clearing the
+   *  queue; SDL handles locking internally for this function.
+   *
+   *  This function always succeeds and thus returns void.
+   *
+   *  \param dev The device ID of which to clear the audio queue.
+   *
+   *  \sa SDL_QueueAudio
+   *  \sa SDL_GetQueuedAudioSize
+   *}
+procedure SDL_ClearQueuedAudio(dev: TSDL_AudioDeviceID); cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_ClearQueuedAudio' {$ENDIF} {$ENDIF};
+
+  {**
    *   Audio lock functions
    *
    *  The lock manipulated by these functions protects the callback function.

--- a/sdlcpuinfo.inc
+++ b/sdlcpuinfo.inc
@@ -71,6 +71,11 @@ function SDL_HasSSE42(): TSDL_Bool cdecl; external SDL_LibName {$IFDEF DELPHI} {
 function SDL_HasAVX(): TSDL_Bool cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasAVX' {$ENDIF} {$ENDIF};
 
 {**
+ *  This function returns true if the CPU has AVX2 features.
+ *}
+function SDL_HasAVX2(): TSDL_Bool cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_HasAVX2' {$ENDIF} {$ENDIF};
+
+{**
  *  This function returns the amount of RAM configured in the system, in MB.
  *}
 function SDL_GetSystemRAM(): Integer cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetSystemRAM' {$ENDIF} {$ENDIF};

--- a/sdlgamecontroller.inc
+++ b/sdlgamecontroller.inc
@@ -119,6 +119,12 @@ function SDL_GameControllerNameForIndex(joystick_index: Integer): PAnsiChar cdec
 function SDL_GameControllerOpen(joystick_index: Integer): PSDL_GameController cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GameControllerOpen' {$ENDIF} {$ENDIF};
 
   {**
+   * Return the SDL_GameController associated with an instance id.
+   *}
+function SDL_GameControllerFromInstanceID(joyid: TSDL_JoystickID): PSDL_GameController; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GameControllerFromInstanceID' {$ENDIF} {$ENDIF};
+
+  {**
    *  Return the name for this currently opened controller
    *}
 function SDL_GameControllerName(gamecontroller: PSDL_GameController): PAnsiChar cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GameControllerName' {$ENDIF} {$ENDIF};

--- a/sdlhints.inc
+++ b/sdlhints.inc
@@ -251,6 +251,16 @@ SDL_HINT_ACCELEROMETER_AS_JOYSTICK = 'SDL_ACCELEROMETER_AS_JOYSTICK';
  */}
 SDL_HINT_XINPUT_ENABLED = 'SDL_XINPUT_ENABLED';
 
+{**
+ *  \brief  A hint that specifies that SDL should use the old axis and button mapping for XInput devices. 
+ *  
+ *  The variable can be set to the following values:
+ *    0  use the old axis and button mapping for XInput devices
+ *    1  do not use old axis and button mapping for XInput devices
+ *  
+ *  By default SDL does not use the old axis and button mapping for XInput devices. 
+ *}
+SDL_HINT_XINPUT_USE_OLD_JOYSTICK_MAPPING = 'SDL_HINT_XINPUT_USE_OLD_JOYSTICK_MAPPING';
 
 {/**
  *  \brief  A variable that lets you manually hint extra gamecontroller db entries
@@ -308,6 +318,15 @@ SDL_HINT_TIMER_RESOLUTION = 'SDL_TIMER_RESOLUTION';
  *  \brief If set to 1, then do not allow high-DPI windows. ("Retina" on Mac)
  *}
 SDL_HINT_VIDEO_HIGHDPI_DISABLED = 'SDL_VIDEO_HIGHDPI_DISABLED';
+
+{**
+ *  \brief  A hint that specifies if the SDL app should not be forced to become a foreground process on Mac OS X. 
+ *  
+ *  Possible values:
+ *    0  force the SDL app to become a foreground process (default)
+ *    1  do not force the SDL app to become a foreground process
+ *}
+SDL_HINT_MAC_BACKGROUND_APP = 'SDL_HINT_MAC_BACKGROUND_APP';
 
 {**
  *  \brief A variable that determines whether ctrl+click should generate a right-click event on Mac
@@ -429,6 +448,122 @@ SDL_HINT_WINRT_HANDLE_BACK_BUTTON = 'SDL_HINT_WINRT_HANDLE_BACK_BUTTON';
    *}
 SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES = 'SDL_VIDEO_MAC_FULLSCREEN_SPACES';
 
+{**
+ *  \brief  A hint that specifies the Android APK expansion main file version. 
+ *  
+ *  The variable should specify the Android APK expansion main file version (a string number like "1", "2" etc.).
+ *  This hint must be set together with the hint SDL_HINT_ANDROID_APK_EXPANSION_PATCH_FILE_VERSION. 
+ *  
+ *  If both hints were set then SDL_RWFromFile() will look into expansion files 
+ *  after a given relative path was not found in the internal storage and assets.
+ *  By default this hint is not set and the APK expansion files are not searched. 
+ *} 
+SDL_HINT_ANDROID_APK_EXPANSION_MAIN_FILE_VERSION = 'SDL_HINT_ANDROID_APK_EXPANSION_MAIN_FILE_VERSION';
+
+{**
+ *  \brief  A hint that specifies the Android APK expansion patch file version. 
+ *  
+ *  The variable should specify the Android APK expansion patch file version (a string number like "1", "2" etc.).
+ *  This hint must be set together with the hint SDL_HINT_ANDROID_APK_EXPANSION_MAIN_FILE_VERSION. 
+ *  
+ *  If both hints were set then SDL_RWFromFile() will look into expansion files 
+ *  after a given relative path was not found in the internal storage and assets.
+ *  By default this hint is not set and the APK expansion files are not searched. 
+ *} 
+SDL_HINT_ANDROID_APK_EXPANSION_PATCH_FILE_VERSION = 'SDL_HINT_ANDROID_APK_EXPANSION_PATCH_FILE_VERSION';
+
+{**
+ *  \brief  A hint that specifies a variable to control whether mouse and touch events are to be treated together or separately.
+ *  
+ *  Possible values:
+ *    0  mouse events will be handled as touch events and touch will raise fake mouse events
+ *    1  mouse events will be handled separately from pure touch events
+ *  
+ *  By default mouse events will be handled as touch events and touch will raise fake mouse events. 
+ *  The value of this hint is used at runtime, so it can be changed at any time. 
+ *}
+SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH = 'SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH';
+
+{**
+ *  \brief A hint that specifies a value to override the binding element for keyboard inputs for Emscripten builds. 
+ *  
+ *  Possible values:
+ *    #window      the JavaScript window object (this is the default)
+ *    #document    the JavaScript document object
+ *    #screen      the JavaScript window.screen object
+ *    #canvas      the default WebGL canvas element
+ *  
+ *  Any other string without a leading # sign applies to the element on the page with that ID. 
+ *  This hint only applies to the Emscripten platform. 
+ *}
+SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT = 'SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT';
+
+{**
+ *  \brief  A hint that specifies whether certain IMEs should handle text editing internally instead of sending SDL_TEXTEDITING events.
+ *  
+ *  Possible values: 
+ *    0  SDL_TEXTEDITING events are sent, and it is the application's responsibility 
+ *       to render the text from these events and differentiate it somehow from committed text. (default)
+ *
+ *    1  If supported by the IME then SDL_TEXTEDITING events are not sent,
+ *       and text that is being composed will be rendered in its own UI.
+ *}
+SDL_HINT_IME_INTERNAL_EDITING = 'SDL_HINT_IME_INTERNAL_EDITING';
+
+{**
+ *  \brief  A hint that specifies not to catch the SIGINT or SIGTERM signals.
+ *
+ *  Possible values:
+ *    0  SDL will install a SIGINT and SIGTERM handler, and when it catches a signal, convert it into an SDL_QUIT event (default)
+ *    1  SDL will not install a signal handler at all
+ *  
+ *  This hint only applies to Unix-like platforms. 
+ *} 
+SDL_HINT_NO_SIGNAL_HANDLERS = 'SDL_HINT_NO_SIGNAL_HANDLERS';
+
+{**
+ *  \brief  A hint that specifies a variable specifying SDL's threads stack size in bytes or "0" for the backend's default size.
+ *  
+ *  Possible values for this hint are:
+ *    0  use the backend's default threads stack size (default)
+ *    X  use the provided positive threads stack size
+ *  
+ *  Use this hint in case you need to set SDL's threads stack size to other than the default.
+ *  This is specially useful if you build SDL against a non glibc libc library (such as musl) 
+ *  which provides a relatively small default thread stack size (a few kilobytes versus the default 8 MB glibc uses).
+ *
+ *  Support for this hint is currently available only in the pthread backend.
+ *}
+SDL_HINT_THREAD_STACK_SIZE = 'SDL_HINT_THREAD_STACK_SIZE';
+
+{**
+ *  \brief  A hint that specifies whether the windows message loop is processed by SDL.
+ *  
+ *  Possible values for this hint:
+ *    0  the window message loop is not run
+ *    1  the window message loop is processed in SDL_PumpEvents()  [default]
+ *}
+SDL_HINT_WINDOWS_ENABLE_MESSAGELOOP = 'SDL_HINT_WINDOWS_ENABLE_MESSAGELOOP';
+
+{**
+ *  \brief  A hint that specifies that SDL should not to generate SDL_WINDOWEVENT_CLOSE events for Alt+F4 on Microsoft Windows.
+ *  
+ *  Possible values for this hint:
+ *    0  generate an SDL_WINDOWEVENT_CLOSE event for Alt+F4 (default)
+ *    1  do not generate event and only do normal key handling for Alt+F4
+ *}
+SDL_HINT_WINDOWS_NO_CLOSE_ON_ALT_F4 = 'SDL_HINT_WINDOWS_NO_CLOSE_ON_ALT_F4';
+
+{**
+ *  \brief  A hint that specifies whether the window frame and title bar are interactive when the cursor is hidden. 
+ *  
+ *  Possible values for this hint:
+ *    0  the window frame is not interactive when the cursor is hidden (no move, resize, etc)
+ *    1  the window frame is interactive when the cursor is hidden
+ *  
+ *  By default SDL will allow interaction with the window frame when the cursor is hidden. 
+ *}
+SDL_HINT_WINDOW_FRAME_USABLE_WHILE_CURSOR_HIDDEN = 'SDL_HINT_WINDOW_FRAME_USABLE_WHILE_CURSOR_HIDDEN';
 
 {/**
  *  \brief  An enumeration of hint priorities

--- a/sdljoystick.inc
+++ b/sdljoystick.inc
@@ -20,6 +20,16 @@ type
   end;
 
   TSDL_JoystickID = SInt32;
+  
+  TSDL_JoystickPowerLevel = (
+    SDL_JOYSTICK_POWER_UNKNOWN = -1,
+    SDL_JOYSTICK_POWER_EMPTY,
+    SDL_JOYSTICK_POWER_LOW,
+    SDL_JOYSTICK_POWER_MEDIUM,
+    SDL_JOYSTICK_POWER_FULL,
+    SDL_JOYSTICK_POWER_WIRED,
+    SDL_JOYSTICK_POWER_MAX
+  );
 
   {* Function prototypes *}
   {**
@@ -45,6 +55,12 @@ function SDL_JoystickNameForIndex(device_index: SInt32): PAnsiChar cdecl; extern
 function SDL_JoystickOpen(device_index: SInt32): PSDL_Joystick cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_JoystickOpen' {$ENDIF} {$ENDIF};
 
   {**
+   * Return the SDL_Joystick associated with an instance id.
+   *}
+function SDL_JoystickFromInstanceID(joyid: TSDL_JoystickID): PSDL_Joystick; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_JoystickFromInstanceID' {$ENDIF} {$ENDIF};
+
+  {**
    *  Return the name for this currently opened joystick.
    *  If no name can be found, this function returns NULL.
    *}
@@ -64,7 +80,7 @@ function SDL_JoystickGetGUID(joystick: PSDL_Joystick): TSDL_JoystickGUID cdecl; 
    *  Return a string representation for this guid. pszGUID must point to at least 33 bytes
    *  (32 for the string plus a NULL terminator).
    *}
-procedure SDL_JoystickGetGUIDString(guid: TSDL_JoystickGUId; pszGUID: PAnsiChar; cbGUID: SInt32) cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_JoystickGetGUIDString' {$ENDIF} {$ENDIF};
+procedure SDL_JoystickGetGUIDString(guid: TSDL_JoystickGUID; pszGUID: PAnsiChar; cbGUID: SInt32) cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_JoystickGetGUIDString' {$ENDIF} {$ENDIF};
 
   {**
    *  convert a string into a joystick formatted guid
@@ -179,7 +195,14 @@ function SDL_JoystickGetBall(joystick: PSDL_Joystick; ball: SInt32; dx: PInt; dy
    *  The button indices start at index 0.
    *}
 function SDL_JoystickGetButton(joystick: PSDL_Joystick; button: SInt32): UInt8 cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_JoystickGetButton' {$ENDIF} {$ENDIF};
+
   {**
    *  Close a joystick previously opened with SDL_JoystickOpen().
    *}
 procedure SDL_JoystickClose(joystick: PSDL_Joystick) cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_JoystickClose' {$ENDIF} {$ENDIF};
+
+  {**
+   *  Return the battery level of this joystick
+   *}
+function SDL_JoystickCurrentPowerLevel(joystick: PSDL_Joystick): TSDL_JoystickPowerLevel; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_JoystickCurrentPowerLevel' {$ENDIF} {$ENDIF};

--- a/sdlmouse.inc
+++ b/sdlmouse.inc
@@ -48,6 +48,33 @@ type
 
   function SDL_GetMouseState(x: PInt; y: PInt): UInt32 cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetMouseState' {$ENDIF}{$ENDIF};
 
+
+  {**
+   *  \brief Get the current state of the mouse, in relation to the desktop
+   *
+   *  This works just like SDL_GetMouseState(), but the coordinates will be
+   *  reported relative to the top-left of the desktop. This can be useful if
+   *  you need to track the mouse outside of a specific window and
+   *  SDL_CaptureMouse() doesn't fit your needs. For example, it could be
+   *  useful if you need to track the mouse while dragging a window, where
+   *  coordinates relative to a window might not be in sync at all times.
+   *
+   *  \note SDL_GetMouseState() returns the mouse position as SDL understands
+   *        it from the last pump of the event queue. This function, however,
+   *        queries the OS for the current mouse position, and as such, might
+   *        be a slightly less efficient function. Unless you know what you're
+   *        doing and have a good reason to use this function, you probably want
+   *        SDL_GetMouseState() instead.
+   *
+   *  \param x Returns the current X coord, relative to the desktop. Can be NULL.
+   *  \param y Returns the current Y coord, relative to the desktop. Can be NULL.
+   *  \return The current button state as a bitmask, which can be tested using the SDL_BUTTON(X) macros.
+   *
+   *  \sa SDL_GetMouseState
+   *}
+  function SDL_GetGlobalMouseState(x, y: PSInt32): UInt32; cdecl;
+    external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetGlobalMouseState' {$ENDIF}{$ENDIF};
+
   {**
    *  Retrieve the relative state of the mouse.
    *
@@ -71,6 +98,18 @@ type
   procedure SDL_WarpMouseInWindow(window: PSDL_Window; x: SInt32; y: SInt32) cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WarpMouseInWindow' {$ENDIF}{$ENDIF};
 
   {**
+   *  \brief Moves the mouse to the given position in global screen space.
+   *
+   *  \param x The x coordinate
+   *  \param y The y coordinate
+   *  \return 0 on success, -1 on error (usually: unsupported by a platform).
+   *
+   *  \note This function generates a mouse motion event
+   *}
+  Function SDL_WarpMouseGlobal(x, y: SInt32): SInt32; cdecl;
+    external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_WarpMouseGlobal' {$ENDIF}{$ENDIF};
+
+  {**
    *  Set relative mouse mode.
    *
    *  enabled Whether or not to enable relative mode
@@ -88,6 +127,38 @@ type
    *}
 
   function SDL_SetRelativeMouseMode(enabled: TSDL_Bool): SInt32 cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetRelativeMouseMode' {$ENDIF}{$ENDIF};
+
+  {**
+   *  \brief Capture the mouse, to track input outside an SDL window.
+   *
+   *  \param enabled Whether or not to enable capturing
+   *
+   *  Capturing enables your app to obtain mouse events globally, instead of
+   *  just within your window. Not all video targets support this function.
+   *  When capturing is enabled, the current window will get all mouse events,
+   *  but unlike relative mode, no change is made to the cursor and it is
+   *  not restrained to your window.
+   *
+   *  This function may also deny mouse input to other windows--both those in
+   *  your application and others on the system--so you should use this
+   *  function sparingly, and in small bursts. For example, you might want to
+   *  track the mouse while the user is dragging something, until the user
+   *  releases a mouse button. It is not recommended that you capture the mouse
+   *  for long periods of time, such as the entire time your app is running.
+   *
+   *  While captured, mouse events still report coordinates relative to the
+   *  current (foreground) window, but those coordinates may be outside the
+   *  bounds of the window (including negative values). Capturing is only
+   *  allowed for the foreground window. If the window loses focus while
+   *  capturing, the capture will be disabled automatically.
+   *
+   *  While capturing is enabled, the current window will have the
+   *  SDL_WINDOW_MOUSE_CAPTURE flag set.
+   *
+   *  \return 0 on success, or -1 if not supported.
+   *}
+   function SDL_CaptureMouse(enabled: TSDL_Bool): SInt32; cdecl;
+     external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_CaptureMouse' {$ENDIF}{$ENDIF};
 
   {**
    *  Query whether relative mouse mode is enabled.

--- a/sdlrect.inc
+++ b/sdlrect.inc
@@ -31,6 +31,11 @@ type
   end;
 
   {**
+   *  \brief Returns true if point resides inside a rectangle.
+   *}
+function SDL_PointInRect(const p: PSDL_Point; const r: PSDL_Rect): Boolean; Inline;
+
+  {**
    *  Returns true if the rectangle has no area.
    *}
 

--- a/sdlrenderer.inc
+++ b/sdlrenderer.inc
@@ -448,6 +448,16 @@ function SDL_RenderSetClipRect(renderer: PSDL_Renderer; rect: PSDL_Rect): SInt32
 procedure SDL_RenderGetClipRect(renderer: PSDL_Renderer; rect: PSDL_Rect) cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderGetClipRect' {$ENDIF} {$ENDIF};
 
   {**
+   *  \brief Get whether clipping is enabled on the given renderer.
+   *
+   *  \param renderer The renderer from which clip state should be queried.
+   *
+   *  \sa SDL_RenderGetClipRect()
+   *}
+function SDL_RenderIsClipEnabled(renderer: PSDL_Renderer): TSDL_Bool; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_RenderIsClipEnabled' {$ENDIF} {$ENDIF};
+
+  {**
    *  Set the drawing scale for rendering on the current target.
    *
    *   renderer The renderer for which the drawing scale should be set.

--- a/sdlsystem.inc
+++ b/sdlsystem.inc
@@ -3,6 +3,15 @@
 (* Platform specific functions for Windows *)
 {$IF DEFINED(WIN32) OR DEFINED(WIN64)} 
 
+  {**
+   *  \brief Set a function that is called for every windows message, before TranslateMessage()
+   *}
+Type
+  TSDL_WindowsMessageHook = Procedure(userdata, hWnd: Pointer; mesage: UInt32; wParam: UInt64; lParam: SInt64); cdecl;
+
+Procedure SDL_SetWindowsMessageHook(callback: TSDL_WindowsMessageHook; userdata: Pointer); cdecl;
+  external SDL_LibName;
+
   {* Returns the D3D9 adapter index that matches the specified display index.
    * This adapter index can be passed to IDirect3D9::CreateDevice and controls
    * on which monitor a full screen application will appear.
@@ -21,7 +30,7 @@ Function SDL_RenderGetD3D9Device(renderer:PSDL_Renderer):PIDirect3DDevice9;
  * These can be passed to EnumAdapters and EnumOutputs respectively to get the objects
  *  required to create a DX10 or DX11 device and swap chain.
  *}
-Procedure SDL_DXGIGetOutputInfo(displayIndex :SInt32; adapterIndex, outputIndex :PSInt32);
+function SDL_DXGIGetOutputInfo(displayIndex :SInt32; adapterIndex, outputIndex :PSInt32): TSDL_Bool;
    cdecl; external SDL_LibName;
 
 {$IFEND}

--- a/sdlversion.inc
+++ b/sdlversion.inc
@@ -25,7 +25,7 @@ type
 const
   SDL_MAJOR_VERSION = 2;
   SDL_MINOR_VERSION = 0;
-  SDL_PATCHLEVEL    = 0;
+  SDL_PATCHLEVEL    = 4;
 
 {**
  *  Macro to determine SDL version program was compiled against.

--- a/sdlvideo.inc
+++ b/sdlvideo.inc
@@ -293,6 +293,32 @@ const
 type
   TSDL_GLcontextFlag = DWord;
 
+  {**
+   *  \brief Possible return values from the SDL_HitTest callback.
+   *
+   *  \sa SDL_HitTest
+   *}
+  TSDL_HitTestResult = (
+    SDL_HITTEST_NORMAL,     {**< Region is normal. No special properties. *}
+    SDL_HITTEST_DRAGGABLE,  {**< Region can drag entire window. *}
+    SDL_HITTEST_RESIZE_TOPLEFT,
+    SDL_HITTEST_RESIZE_TOP,
+    SDL_HITTEST_RESIZE_TOPRIGHT,
+    SDL_HITTEST_RESIZE_RIGHT,
+    SDL_HITTEST_RESIZE_BOTTOMRIGHT,
+    SDL_HITTEST_RESIZE_BOTTOM,
+    SDL_HITTEST_RESIZE_BOTTOMLEFT,
+    SDL_HITTEST_RESIZE_LEFT
+  );
+
+  {**
+   *  \brief Callback used for hit-testing.
+   *
+   *  \sa SDL_SetWindowHitTest
+   *}
+  TSDL_HitTest = Function(win: PSDL_Window; const area: PSDL_Point; data: Pointer): TSDL_HitTestResult; cdecl;
+
+
   {* Function prototypes *}
 
   {**
@@ -380,6 +406,19 @@ function SDL_GetDisplayName(displayIndex: SInt32): PAnsiChar cdecl; external SDL
    *}
 
 function SDL_GetDisplayBounds(displayIndex: SInt32; rect: PSDL_Rect): SInt32 cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetDisplayBounds' {$ENDIF} {$ENDIF};
+
+  {**
+   *  \brief Get the dots/pixels-per-inch for a display
+   *
+   *  \note Diagonal, horizontal and vertical DPI can all be optionally
+   *        returned if the parameter is non-NULL.
+   *
+   *  \return 0 on success, or -1 if no DPI information is available or the index is out of range.
+   *
+   *  \sa SDL_GetNumVideoDisplays()
+   *}
+function SDL_GetDisplayDPI(displayIndex: SInt32; ddpi, hdpi, vdpi: PSingle): SInt32; cdecl; 
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetDisplayDPI' {$ENDIF} {$ENDIF}; 
 
   {**
    *  Returns the number of available display modes.
@@ -825,6 +864,16 @@ procedure SDL_SetWindowGrab(window: PSDL_Window; grabbed: TSDL_Bool) cdecl; exte
 function SDL_GetWindowGrab(window: PSDL_Window): TSDL_Bool cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetWindowGrab' {$ENDIF} {$ENDIF};
 
   {**
+   *  \brief Get the window that currently has an input grab enabled.
+   *
+   *  \return This returns the window if input is grabbed, and NULL otherwise.
+   *
+   *  \sa SDL_SetWindowGrab()
+   *}
+function SDL_GetGrabbedWindow(): PSDL_Window; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetGrabbedWindow' {$ENDIF} {$ENDIF};
+
+  {**
    *  Set the brightness (gamma correction) for a window.
    *
    *  0 on success, or -1 if setting the brightness isn't supported.
@@ -881,6 +930,46 @@ function SDL_SetWindowGammaRamp(window: PSDL_Window; const red: PUInt16; const g
    *}
 
 function SDL_GetWindowGammaRamp(window: PSDL_Window; red: PUInt16; green: PUInt16; blue: PUInt16): SInt32 cdecl; external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_GetWindowGammaRamp' {$ENDIF} {$ENDIF};
+
+  {**
+   *  \brief Provide a callback that decides if a window region has special properties.
+   *
+   *  Normally windows are dragged and resized by decorations provided by the
+   *  system window manager (a title bar, borders, etc), but for some apps, it
+   *  makes sense to drag them from somewhere else inside the window itself; for
+   *  example, one might have a borderless window that wants to be draggable
+   *  from any part, or simulate its own title bar, etc.
+   *
+   *  This function lets the app provide a callback that designates pieces of
+   *  a given window as special. This callback is run during event processing
+   *  if we need to tell the OS to treat a region of the window specially; the
+   *  use of this callback is known as "hit testing."
+   *
+   *  Mouse input may not be delivered to your application if it is within
+   *  a special area; the OS will often apply that input to moving the window or
+   *  resizing the window and not deliver it to the application.
+   *
+   *  Specifying NULL for a callback disables hit-testing. Hit-testing is
+   *  disabled by default.
+   *
+   *  Platforms that don't support this functionality will return -1
+   *  unconditionally, even if you're attempting to disable hit-testing.
+   *
+   *  Your callback may fire at any time, and its firing does not indicate any
+   *  specific behavior (for example, on Windows, this certainly might fire
+   *  when the OS is deciding whether to drag your window, but it fires for lots
+   *  of other reasons, too, some unrelated to anything you probably care about
+   *  _and when the mouse isn't actually at the location it is testing_).
+   *  Since this can fire at any time, you should try to keep your callback
+   *  efficient, devoid of allocations, etc.
+   *
+   *  \param window The window to set hit-testing on.
+   *  \param callback The callback to call when doing a hit-test.
+   *  \param callback_data An app-defined void pointer passed to the callback.
+   *  \return 0 on success, -1 on error (including unsupported).
+   *}
+Function SDL_SetWindowHitTest(window: PSDL_Window; callback: TSDL_HitTest; callback_data: Pointer): SInt32; cdecl;
+  external SDL_LibName {$IFDEF DELPHI} {$IFDEF MACOS} name '_SDL_SetWindowHitTest' {$ENDIF} {$ENDIF};
 
   {**
    *  Destroy a window.


### PR DESCRIPTION
This commit adds headers for new functions which were introduced in SDL 2.0.4.
Header version number in `sdlversion.inc` was appropriately bumped up to reflect the change. 