### PR TITLE
Modified IFDEF's to support FreeBSD too.

### DIFF
--- a/sdl2.pas
+++ b/sdl2.pas
@@ -136,17 +136,13 @@ interface
       Windows;
   {$ENDIF}
 
-  {$IFDEF LINUX}
+  {$IFDEF UNIX}
     uses
+      {$IFDEF DARWIN}
+      CocoaAll,
+      {$ENDIF}
       X,
       XLib;
-  {$ENDIF}
-  
-  {$IFDEF DARWIN}
-    uses
-      X,
-      XLib,
-      CocoaAll;
   {$ENDIF}
 
 const


### PR DESCRIPTION
As the subject line says. It’s a minor change, but now it works under FreeBSD with FPC as well.