### PR TITLE
remove redundant include of jedi.inc in sdlhaptic.inc

### DIFF
--- a/sdlhaptic.inc
+++ b/sdlhaptic.inc
@@ -89,8 +89,6 @@
  *  Edgar Simo Serra
  *}
 
-{$I jedi.inc}
-
   {**
    *   SDL_Haptic
    *


### PR DESCRIPTION
As per subject. Haptic is included in sdl2.pas, which itself includes jedi.inc.