### PR TITLE
Fix syntax error (typo: space in const name) in sdlrenderer.inc

### DIFF
--- a/sdlrenderer.inc
+++ b/sdlrenderer.inc
@@ -56,7 +56,7 @@ type
    *  Flip constants for SDL_RenderCopyEx
    *}
 const
-  S DL_FLIP_NONE       = $0; {**< Do not flip *}
+  SDL_FLIP_NONE       = $0; {**< Do not flip *}
   SDL_FLIP_HORIZONTAL = $1; {**< flip horizontally *}
   SDL_FLIP_VERTICAL   = $2; {**< flip vertically *}
 


### PR DESCRIPTION
This changeset fixes a syntax error caused by a space appearing in the name of a const.