### PR TITLE
Added SDL_PRESSED and SDL_RELEASED to sdlevents.inc

### DIFF
--- a/sdlevents.inc
+++ b/sdlevents.inc
@@ -6,6 +6,10 @@
 
 const
 
+  { General keyboard/mouse state definitions }
+  SDL_RELEASED         = 0;
+  SDL_PRESSED          = 1;
+
   SDL_FIRSTEVENT       = 0;     // Unused (do not remove) (needed in pascal?)
 
   SDL_COMMONEVENT      = 1;     //added for pascal-compatibility


### PR DESCRIPTION
These constants can be used with KeyboardEvent, MouseButtonEvent, JoyButtonEvent and ControllerButtonEvent, but they were never actually defined.