### PR TITLE
Fix building on Android

### DIFF
--- a/sdl2.pas
+++ b/sdl2.pas
@@ -138,7 +138,7 @@ interface
       Windows;
   {$ENDIF}
 
-  {$IFDEF UNIX}
+  {$IF DEFINED(UNIX) AND NOT DEFINED(ANDROID)}
     uses
       {$IFDEF DARWIN}
       CocoaAll,

--- a/sdlsyswm.inc
+++ b/sdlsyswm.inc
@@ -4,7 +4,7 @@
    {$DEFINE SDL_VIDEO_DRIVER_WINDOWS}
 {$ENDIF}
 
-{$IF DEFINED (LINUX) OR DEFINED(UNIX)}
+{$IF DEFINED (LINUX) OR DEFINED(UNIX) AND NOT DEFINED(ANDROID)}
    {$DEFINE SDL_VIDEO_DRIVER_X11}
 {$IFEND}
 
@@ -158,8 +158,8 @@ Type
 {$ENDIF}
 {$IFDEF SDL_VIDEO_DRIVER_ANDROID}
    __WMINFO_ANDROID = record
-      window:  PANativeWindow;
-      surface: PEGLSurface;
+      window:  Pointer;  // PANativeWindow;
+      surface: Pointer;  // PEGLSurface;
    end;
 {$ENDIF}
 {$IFDEF SDL_VIDEO_DRIVER_VIVANTE}


### PR DESCRIPTION
FPC for Android target defines both ANDROID and UNIX macro. But then unit X and Xlib are used, which Android doesn't have.

I also modified  record __WMINFO_ANDROID. Instead of undefined PANativeWindow and PEGLSurface types I simply put Pointer (since those fields ARE pointers, and we won't use those anyways)