### PR TITLE
Correct value of SDLK_QUOTE constant

### DIFF
--- a/sdlscancode.inc
+++ b/sdlscancode.inc
@@ -393,7 +393,7 @@ const
   SDLK_PERCENT = TSDL_KeyCode('%');
   SDLK_DOLLAR = TSDL_KeyCode('$');
   SDLK_AMPERSAND = TSDL_KeyCode('&');
-  SDLK_QUOTE = TSDL_KeyCode('\');
+  SDLK_QUOTE = TSDL_KeyCode('''');
   SDLK_LEFTPAREN = TSDL_KeyCode('(');
   SDLK_RIGHTPAREN = TSDL_KeyCode(')');
   SDLK_ASTERISK = TSDL_KeyCode('*');


### PR DESCRIPTION
The value of `SDLK_QUOTE` constant is incorrect and the same as `SDLK_BACKSLASH`, that's probably a result of escape characters being different between C and Pascal.